### PR TITLE
Updated Readme.md - RAK RPi Converter Board reset pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Rising HF Board<br />http://www.risinghf.com/product/risinghf-iot-dicovery/?lang
 IMST backplane or Lite gateway<br />https://wireless-solutions.de/products/long-range-radio/lora_lite_gateway.html | 29 (untested)
 Coredump backplane<br />https://github.com/dbrgn/ic880a-backplane/<br />https://shop.coredump.ch/product/ic880a-lorawan-gateway-backplane/ | 22
 RAK backplane<br /> | 11
+RAK RAK831 RPi Converter Board | 17
 
 
 If you get the message


### PR DESCRIPTION
Also see: http://docs.rakwireless.com/en/RAK831%20LoRa%20Gateway/Hardware%20Design/Raspberry%20Pi%20Switchboard%20SCH_20171218.PDF
GPIO 17/pin 11 is connected to the reset pin (pin 19) towards the RAK831 module. 