### PR TITLE
Modification for stable cellular usage

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -11,6 +11,8 @@ RUN ./dev/build.sh
 
 FROM resin/%%RESIN_MACHINE_NAME%%-debian:latest
 
+ENV UDEV=off
+
 WORKDIR /opt/ttn-gateway
 
 RUN apt-get update && \

--- a/Dockerfile.template.metering
+++ b/Dockerfile.template.metering
@@ -4,6 +4,8 @@ FROM resin/%%RESIN_MACHINE_NAME%%-debian:latest AS buildstep
 RUN apt-get update && \
     apt-get install wget build-essential libc6-dev git pkg-config protobuf-compiler libprotobuf-dev libprotoc-dev automake libtool autoconf python-dev python-rpi.gpio
 
+ENV UDEV=off
+
 WORKDIR /etc
 
 # versions

--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ GW_KEY            | The gateway KEY from the TTN console
 GW_GPS            | true
 GW_RESET_PIN      | 29
 
+### Device environment variables - with cellular modem
+
+For example, for an HUAWEI MS2131 cellular modem, the MINIMUM environment variables that you should configure at this screen should look something like this:
+
+Name      	  	   | Value  
+------------------|--------------------------  
+GW_ID             | The gateway ID from the TTN console
+GW_KEY            | The gateway KEY from the TTN console
+GW_RESET_PIN      | 22 (optional)
+CELLULAR_WAIT     | 240
+
+run.py will wait for 240s until cellular modem connection is ready to pull data from internet. Time should be adjusted to your setup. If wait time is too short, gateway will not start sucesfull. 
 
 ## Reset pin values
 

--- a/run.py
+++ b/run.py
@@ -27,8 +27,8 @@ if os.environ.get('HALT') != None:
   print ("*** HALT asserted - exiting ***")
   sys.exit(0)
   
- if os.environ.get("CELLULAR_WAIT") != None:
-  cellular_wait_s = os.environ.get("CELLULAR_WAIT")
+ if os.environ.get('CELLULAR_WAIT') != None:
+  cellular_wait_s = os.environ.get('CELLULAR_WAIT')
   print ("*** Wait time for cellular connnection in s: "+str(os.environ.get('CELLULAR_WAIT')))
   sleep(cellular_wait_s)
 

--- a/run.py
+++ b/run.py
@@ -27,11 +27,6 @@ if os.environ.get('HALT') != None:
   print ("*** HALT asserted - exiting ***")
   sys.exit(0)
   
-if os.environ.get('CELLULAR_WAIT') != None:
-  cellular_wait_s = float(os.environ.get('CELLULAR_WAIT'))
-  print ("*** Wait time for cellular connnection in s: "+str(os.environ.get('CELLULAR_WAIT')))
-  time.sleep(cellular_wait_s)
-
 # Show info about the machine we're running on
 print ("*** Resin Machine Info:")
 print ("*** Type: "+str(os.environ.get('RESIN_MACHINE_NAME')))
@@ -112,14 +107,17 @@ if(os.getenv('SERVER_TTN', "true")=="true"):
 
   # Fetch the URL, if it fails try 30 seconds later again.
   config_response = ""
-  try:
-    req = urllib2.Request('https://%s/api/v2/gateways/%s' % (account_server_domain, my_gw_id))
-    req.add_header('Authorization', 'Key '+os.environ.get("GW_KEY"))
-    response = urllib2.urlopen(req, timeout=30)
-    config_response = response.read()
-  except urllib2.URLError as err: 
-    print ("Unable to fetch configuration from TTN. Are your GW_ID and GW_KEY correct?")
-    sys.exit(0)
+  while True:
+    try:
+      req = urllib2.Request('https://%s/api/v2/gateways/%s' % (account_server_domain, my_gw_id))
+      req.add_header('Authorization', 'Key '+os.environ.get("GW_KEY"))
+      response = urllib2.urlopen(req, timeout=30)
+      config_response = response.read()
+    except urllib2.URLError as err: 
+      print ("Unable to fetch configuration from TTN. Is the TTN API reachable from gateway? Are your GW_ID and GW_KEY correct?")
+      time.sleep(30)
+      continue
+    break
 
   # Parse config
   ttn_config = {}

--- a/run.py
+++ b/run.py
@@ -26,6 +26,10 @@ if not os.path.exists("/opt/ttn-gateway/mp_pkt_fwd"):
 if os.environ.get('HALT') != None:
   print ("*** HALT asserted - exiting ***")
   sys.exit(0)
+  
+ if os.environ.get("CELLULAR_WAIT") != None:
+  cellular_wait_s = os.environ.get("CELLULAR_WAIT")
+  sleep(cellular_wait_s);
 
 # Show info about the machine we're running on
 print ("*** Resin Machine Info:")

--- a/run.py
+++ b/run.py
@@ -28,7 +28,7 @@ if os.environ.get('HALT') != None:
   sys.exit(0)
   
 if os.environ.get('CELLULAR_WAIT') != None:
-  cellular_wait_s = os.environ.get('CELLULAR_WAIT')
+  cellular_wait_s = float(os.environ.get('CELLULAR_WAIT'))
   print ("*** Wait time for cellular connnection in s: "+str(os.environ.get('CELLULAR_WAIT')))
   time.sleep(cellular_wait_s)
 

--- a/run.py
+++ b/run.py
@@ -29,7 +29,8 @@ if os.environ.get('HALT') != None:
   
  if os.environ.get("CELLULAR_WAIT") != None:
   cellular_wait_s = os.environ.get("CELLULAR_WAIT")
-  sleep(cellular_wait_s);
+  print ("*** Wait time for cellular connnection in s: "+str(os.environ.get('CELLULAR_WAIT')))
+  sleep(cellular_wait_s)
 
 # Show info about the machine we're running on
 print ("*** Resin Machine Info:")

--- a/run.py
+++ b/run.py
@@ -30,7 +30,7 @@ if os.environ.get('HALT') != None:
 if os.environ.get('CELLULAR_WAIT') != None:
   cellular_wait_s = os.environ.get('CELLULAR_WAIT')
   print ("*** Wait time for cellular connnection in s: "+str(os.environ.get('CELLULAR_WAIT')))
-  sleep(cellular_wait_s)
+  time.sleep(cellular_wait_s)
 
 # Show info about the machine we're running on
 print ("*** Resin Machine Info:")

--- a/run.py
+++ b/run.py
@@ -27,7 +27,7 @@ if os.environ.get('HALT') != None:
   print ("*** HALT asserted - exiting ***")
   sys.exit(0)
   
- if os.environ.get('CELLULAR_WAIT') != None:
+if os.environ.get('CELLULAR_WAIT') != None:
   cellular_wait_s = os.environ.get('CELLULAR_WAIT')
   print ("*** Wait time for cellular connnection in s: "+str(os.environ.get('CELLULAR_WAIT')))
   sleep(cellular_wait_s)


### PR DESCRIPTION
Added ENV UDEV=off in dockerfiles to avoid udev conflict from container with host that leads to dissapering of modem.
Added optional environment variable CELLULAR_WAIT, so the run.py in container will wait until cellular connection of host is established. 