### PR TITLE
Fix for stable cellular usage

### DIFF
--- a/Dockerfile.template.metering
+++ b/Dockerfile.template.metering
@@ -4,6 +4,8 @@ FROM resin/%%RESIN_MACHINE_NAME%%-debian:latest AS buildstep
 RUN apt-get update && \
     apt-get install wget build-essential libc6-dev git pkg-config protobuf-compiler libprotobuf-dev libprotoc-dev automake libtool autoconf python-dev python-rpi.gpio
 
+ENV UDEV=off
+
 WORKDIR /etc
 
 # versions

--- a/run.py
+++ b/run.py
@@ -107,14 +107,17 @@ if(os.getenv('SERVER_TTN', "true")=="true"):
 
   # Fetch the URL, if it fails try 30 seconds later again.
   config_response = ""
-  try:
-    req = urllib2.Request('https://%s/api/v2/gateways/%s' % (account_server_domain, my_gw_id))
-    req.add_header('Authorization', 'Key '+os.environ.get("GW_KEY"))
-    response = urllib2.urlopen(req, timeout=30)
-    config_response = response.read()
-  except urllib2.URLError as err: 
-    print ("Unable to fetch configuration from TTN. Are your GW_ID and GW_KEY correct?")
-    sys.exit(0)
+  while True:
+    try:
+      req = urllib2.Request('https://%s/api/v2/gateways/%s' % (account_server_domain, my_gw_id))
+      req.add_header('Authorization', 'Key '+os.environ.get("GW_KEY"))
+      response = urllib2.urlopen(req, timeout=30)
+      config_response = response.read()
+    except urllib2.URLError as err: 
+      print ("Unable to fetch configuration from TTN. Is the TTN API reachable from gateway? Are your GW_ID and GW_KEY correct? Retry       in 30s")
+      time.sleep(30)
+      continue
+    break
 
   # Parse config
   ttn_config = {}


### PR DESCRIPTION
Added ENV UDEV=off in dockerfiles to avoid udev conflict from container with host that leads to dissapering of modem.
Added retry loop after 30s if TTN api is not yet reachable. 